### PR TITLE
Fix for #7

### DIFF
--- a/bbb-player.py
+++ b/bbb-player.py
@@ -79,7 +79,7 @@ def downloadFiles(baseURL, basePath):
 
 def downloadSlides(baseURL, basePath):
     # Part of this is based on https://www.programiz.com/python-programming/json
-    with open(basePath + '/presentation_text.json') as f:
+    with open(basePath + '/presentation_text.json', encoding="utf8") as f:
         data = json.load(f)
         logger.info(f"Downloading {len(data)} presentations")
         for element in data:


### PR DESCRIPTION
Fixed #7, error when downloading and the platform has a different encoding than expected.
`open` by default uses platform specific encoding [("If encoding is not specified, the default is platform dependent")](https://docs.python.org/3/tutorial/inputoutput.html). This PR fixes the issue by specifying UTF-8.