### PR TITLE
Added sequential naming

### DIFF
--- a/bbb-player.py
+++ b/bbb-player.py
@@ -465,6 +465,7 @@ if __name__ == "__main__":
         inputFile = args.download_list[0]
         with open(inputFile, 'r', encoding="utf-8") as f:
             for count, line in enumerate(f):
+                count += 1
                 line = line.strip()
                 if meetingNamesWanted:
                     meetingNameWanted = meetingNamesWanted.pop(0)

--- a/bbb-player.py
+++ b/bbb-player.py
@@ -410,6 +410,10 @@ if __name__ == "__main__":
                        help="download the BBB conferences listed in this file \
                             (one url per line) \
                             you can use the -n argument to define names for the conferences from a file")
+    group.add_argument("-sq", "--sequence", type=str, nargs=1,
+                       help="use this argument for sequential naming of the conferences \
+                            (e.g. meeting1, meeting2, meeting3, ...) \
+                            example: -dl urls.txt -sq video-")
     group.add_argument("-s", "--server", action="store_true",
                        help="launch a server with all available downloaded meetings listed on one page")
     group.add_argument("-c", "--combine", type=str, nargs=1,
@@ -451,7 +455,7 @@ if __name__ == "__main__":
     elif args.download_list is not None and args.download is None and args.server is False and args.combine is None:
         logger.info(f"Download links from file: {args.download_list[0]}")
         meetingNamesWanted = []
-        if args.name:
+        if args.name and args.sequence is None:
             logger.info("Reading meeting names from file.")
             with open(args.name[0], 'r', encoding="utf-8") as f:
                 names = f.read().rstrip()
@@ -460,10 +464,15 @@ if __name__ == "__main__":
 
         inputFile = args.download_list[0]
         with open(inputFile, 'r', encoding="utf-8") as f:
-            for line in f:
+            for count, line in enumerate(f):
                 line = line.strip()
                 if meetingNamesWanted:
                     meetingNameWanted = meetingNamesWanted.pop(0)
+                    logger.info(f"Naming the meeting as: {meetingNameWanted}")
+                    logger.info(f"Downloading link: {line}")
+                    downloadScript(line, meetingNameWanted)
+                elif args.sequence is not None:
+                    meetingNameWanted = args.sequence[0] + str(count)
                     logger.info(f"Naming the meeting as: {meetingNameWanted}")
                     logger.info(f"Downloading link: {line}")
                     downloadScript(line, meetingNameWanted)

--- a/bbb-player.py
+++ b/bbb-player.py
@@ -473,7 +473,7 @@ if __name__ == "__main__":
                     logger.info(f"Downloading link: {line}")
                     downloadScript(line, meetingNameWanted)
                 elif args.sequence is not None:
-                    meetingNameWanted = args.sequence[0] + str(count)
+                    meetingNameWanted = args.sequence[0] + str(count).zfill(2)
                     logger.info(f"Naming the meeting as: {meetingNameWanted}")
                     logger.info(f"Downloading link: {line}")
                     downloadScript(line, meetingNameWanted)


### PR DESCRIPTION
This change adds a new optional argument, `--sequence`, to the command-line argument parser. This argument allows the user to specify a sequence of names for the conferences, that the script will use. The numbers will be appended to the `--sequence` string to create the final conference names (e.g. "video-" becomes "video-01", "video-02", etc.).

I think this will be a useful feature for users who want to specify a custom naming scheme for their conferences.